### PR TITLE
post-demo-updates

### DIFF
--- a/docs/shared/chgres_cube.yaml
+++ b/docs/shared/chgres_cube.yaml
@@ -2,28 +2,28 @@ chgres_cube:
   execution:
     executable: chgres_cube
     mpiargs:
-      - "--export=NONE"
+      - --export=NONE
     mpicmd: srun
     threads: 1
   namelist:
     update_values:
       config:
-        atm_files_input_grid: "gfs.t{{ cycle.strftime('%h') }}z.atmanl.nemsio"
+        atm_files_input_grid: gfs.t{{ cycle.strftime('%h') }}z.atmanl.nemsio
         convert_atm: true
         convert_nst: true
         convert_sfc: true
         cycle_day: !int "{{ cycle.strftime('%d') }}"
         cycle_hour: !int "{{ cycle.strftime('%H') }}"
         cycle_mon: !int "{{ cycle.strftime('%m') }}"
-        data_dir_input_grid: "/path/to/data/{{ cycle.strftime('%Y%M%d%H') }}"
+        data_dir_input_grid: /path/to/data/{{ cycle.strftime('%Y%M%d%H') }}
         fix_dir_target_grid: /path/to/fixdir
         mosaic_file_target_grid: /path/to/mosaic/C432.mosaic.halo4.nc
         orog_files_target_grid: /path/to/orog/C432.oro_data.tile7.halo4.nc
         vcoord_file_target_grid: /path/to/global_hyblev.l65.txt
         varmap_file: /path/to/varmap_table
-        grib2_file_input_grid: "a.file.gb2"
-        sfc_files_input_grid: "sfc.t{{cycle.strftime('%H') }}z.nc"
-        atm_files_input_grid: "atm.t{{cycle.strftime('%H') }}z.nc"
+        grib2_file_input_grid: a.file.gb2
+        sfc_files_input_grid: sfc.t{{cycle.strftime('%H') }}z.nc
+        atm_files_input_grid: atm.t{{cycle.strftime('%H') }}z.nc
   run_dir: /path/to/dir
 platform:
   account: foo

--- a/docs/shared/sfc_climo_gen.yaml
+++ b/docs/shared/sfc_climo_gen.yaml
@@ -10,8 +10,8 @@ sfc_climo_gen:
      - module load some_module
    executable: /path/to/sfc_climo_gen
    mpiargs:
-     - "--export=ALL"
-     - "--ntasks $SLURM_CPUS_ON_NODE"
+     - --export=ALL
+     - --ntasks $SLURM_CPUS_ON_NODE
    mpicmd: srun
  namelist:
    update_values:

--- a/docs/shared/ungrib.yaml
+++ b/docs/shared/ungrib.yaml
@@ -3,7 +3,7 @@ ungrib:
     batchargs:
       cores: 1
       walltime: 00:01:00
-    executable: "/path/to/ungrib.exe"
-  gfs_file: "/path/to/dir/gfs.t12z.pgrb2.0p25.f000"
-  run_dir: "/path/to/dir/run"
-  vtable: "/path/to/Vtable.GFS"
+    executable: /path/to/ungrib.exe
+  gfs_file: /path/to/dir/gfs.t12z.pgrb2.0p25.f000
+  run_dir: /path/to/dir/run
+  vtable: /path/to/Vtable.GFS

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -11,10 +11,10 @@
 # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#test-section
 
 cli() {
-  msg Testing CLI program
+  msg Testing CLI
   (
     set -eux
-    uw --help >/dev/null
+    uw --version
   )
   msg OK
 }

--- a/src/uwtools/api/chgres_cube.py
+++ b/src/uwtools/api/chgres_cube.py
@@ -25,13 +25,13 @@ def execute(
     If ``batch`` is specified, a runscript will be written and submitted to the batch system.
     Otherwise, the executable will be run directly on the current system.
 
-    :param task: The task to execute
-    :param cycle: The cycle to run
+    :param task: The task to execute.
+    :param cycle: The synoptic time.
     :param config: Path to config file (read stdin if missing or None).
-    :param batch: Submit run to the batch system
-    :param dry_run: Do not run the executable, just report what would have been done
-    :param graph_file: Write Graphviz DOT output here
-    :return: ``True`` if task completes without raising an exception
+    :param batch: Submit run to the batch system.
+    :param dry_run: Do not run the executable, just report what would have been done.
+    :param graph_file: Write Graphviz DOT output here.
+    :return: ``True`` if task completes without raising an exception.
     """
     obj = _ChgresCube(config=config, cycle=cycle, batch=batch, dry_run=dry_run)
     getattr(obj, task)()

--- a/src/uwtools/api/fv3.py
+++ b/src/uwtools/api/fv3.py
@@ -23,13 +23,13 @@ def execute(
     If ``batch`` is specified, a runscript will be written and submitted to the batch system.
     Otherwise, the forecast will be run directly on the current system.
 
-    :param task: The task to execute
-    :param cycle: The cycle to run
+    :param task: The task to execute.
+    :param cycle: The synoptic time.
     :param config: Path to config file (read stdin if missing or None).
-    :param batch: Submit run to the batch system
-    :param dry_run: Do not run forecast, just report what would have been done
-    :param graph_file: Write Graphviz DOT output here
-    :return: ``True`` if task completes without raising an exception
+    :param batch: Submit run to the batch system.
+    :param dry_run: Do not run forecast, just report what would have been done.
+    :param graph_file: Write Graphviz DOT output here.
+    :return: ``True`` if task completes without raising an exception.
     """
     obj = _FV3(config=config, cycle=cycle, batch=batch, dry_run=dry_run)
     getattr(obj, task)()

--- a/src/uwtools/api/ungrib.py
+++ b/src/uwtools/api/ungrib.py
@@ -23,13 +23,13 @@ def execute(
     If ``batch`` is specified, a runscript will be written and submitted to the batch system.
     Otherwise, the executable will be run directly on the current system.
 
-    :param task: The task to execute
-    :param cycle: The cycle to run
+    :param task: The task to execute.
+    :param cycle: The synoptic time.
     :param config: Path to config file (read stdin if missing or None).
-    :param batch: Submit run to the batch system
-    :param dry_run: Do not run the executable, just report what would have been done
-    :param graph_file: Write Graphviz DOT output here
-    :return: ``True`` if task completes without raising an exception
+    :param batch: Submit run to the batch system.
+    :param dry_run: Do not run the executable, just report what would have been done.
+    :param graph_file: Write Graphviz DOT output here.
+    :return: ``True`` if task completes without raising an exception.
     """
     obj = _Ungrib(config=config, cycle=cycle, batch=batch, dry_run=dry_run)
     getattr(obj, task)()

--- a/src/uwtools/drivers/chgres_cube.py
+++ b/src/uwtools/drivers/chgres_cube.py
@@ -29,13 +29,12 @@ class ChgresCube(Driver):
         """
         The driver.
 
-        :param cycle: The date cycle.
+        :param cycle: The synoptic time.
         :param config: Path to config file (read stdin if missing or None).
         :param dry_run: Run in dry-run mode?
         :param batch: Run component via the batch system?
         """
-        super().__init__(config=config, dry_run=dry_run, batch=batch)
-        self._config.dereference(context={"cycle": cycle})
+        super().__init__(config=config, dry_run=dry_run, batch=batch, cycle=cycle)
         if self._dry_run:
             dryrun()
         self._cycle = cycle

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -5,6 +5,7 @@ import os
 import re
 import stat
 from abc import ABC, abstractmethod
+from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Dict, List, Optional, Type
@@ -25,7 +26,11 @@ class Driver(ABC):
     """
 
     def __init__(
-        self, config: Optional[Path] = None, dry_run: bool = False, batch: bool = False
+        self,
+        config: Optional[Path] = None,
+        dry_run: bool = False,
+        batch: bool = False,
+        cycle: Optional[datetime] = None,
     ) -> None:
         """
         A component driver.
@@ -33,11 +38,14 @@ class Driver(ABC):
         :param config: Path to config file (read stdin if missing or None).
         :param dry_run: Run in dry-run mode?
         :param batch: Run component via the batch system?
+        :param cycle: The synoptic time.
         """
         self._config = YAMLConfig(config=config)
         self._dry_run = dry_run
         self._batch = batch
         self._config.dereference()
+        if cycle:
+            self._config.dereference(context={"cycle": cycle})
         self._validate()
 
     # Workflow tasks

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -15,6 +15,7 @@ from iotaa import asset, task, tasks
 from uwtools.config.formats.base import Config
 from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.config.validator import validate_internal
+from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
 from uwtools.scheduler import JobScheduler
 from uwtools.utils.processing import execute
@@ -141,10 +142,14 @@ class Driver(ABC):
         """
         Returns configuration data for the runscript.
         """
+        try:
+            platform = self._config["platform"]
+        except KeyError as e:
+            raise UWConfigError("Required 'platform' block missing in config") from e
         return {
-            "account": self._config["platform"]["account"],
+            "account": platform["account"],
             "rundir": self._rundir,
-            "scheduler": self._config["platform"]["scheduler"],
+            "scheduler": platform["scheduler"],
             **self._driver_config.get("execution", {}).get("batchargs", {}),
         }
 

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -119,8 +119,12 @@ class Driver(ABC):
         """
         Returns the config block specific to this driver.
         """
-        driver_config: Dict[str, Any] = self._config[self._driver_name]
-        return driver_config
+        name = self._driver_name
+        try:
+            driver_config: Dict[str, Any] = self._config[name]
+            return driver_config
+        except KeyError as e:
+            raise UWConfigError("Required '%s' block missing in config" % name) from e
 
     @property
     @abstractmethod

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -44,8 +44,9 @@ class Driver(ABC):
         self._dry_run = dry_run
         self._batch = batch
         self._config.dereference()
-        if cycle:
-            self._config.dereference(context={"cycle": cycle})
+        self._config.dereference(
+            context={**({"cycle": cycle} if cycle else {}), **self._config.data}
+        )
         self._validate()
 
     # Workflow tasks

--- a/src/uwtools/drivers/fv3.py
+++ b/src/uwtools/drivers/fv3.py
@@ -33,13 +33,12 @@ class FV3(Driver):
         """
         The driver.
 
-        :param cycle: The forecast cycle.
+        :param cycle: The synoptic time.
         :param config: Path to config file (read stdin if missing or None).
         :param dry_run: Run in dry-run mode?
         :param batch: Run component via the batch system?
         """
-        super().__init__(config=config, dry_run=dry_run, batch=batch)
-        self._config.dereference(context={"cycle": cycle})
+        super().__init__(config=config, dry_run=dry_run, batch=batch, cycle=cycle)
         if self._dry_run:
             dryrun()
         self._cycle = cycle

--- a/src/uwtools/drivers/ungrib.py
+++ b/src/uwtools/drivers/ungrib.py
@@ -42,9 +42,9 @@ class Ungrib(Driver):
     # Workflow tasks
 
     @task
-    def gribfile_aaa(self):
+    def gribfile(self):
         """
-        The gribfile.
+        A symlink to the input GRIB file.
         """
         path = self._rundir / "GRIBFILE.AAA"
         yield self._taskname(str(path))
@@ -92,7 +92,7 @@ class Ungrib(Driver):
         """
         yield self._taskname("provisioned run directory")
         yield [
-            self.gribfile_aaa(),
+            self.gribfile(),
             self.namelist_file(),
             self.runscript(),
             self.vtable(),
@@ -112,7 +112,7 @@ class Ungrib(Driver):
     @task
     def vtable(self):
         """
-        The Vtable.
+        A symlink to the Vtable file.
         """
         path = self._rundir / "Vtable"
         yield self._taskname(str(path))

--- a/src/uwtools/drivers/ungrib.py
+++ b/src/uwtools/drivers/ungrib.py
@@ -29,13 +29,12 @@ class Ungrib(Driver):
         """
         The driver.
 
-        :param cycle: The forecast cycle.
+        :param cycle: The synoptic time.
         :param config: Path to config file (read stdin if missing or None).
         :param dry_run: Run in dry-run mode?
         :param batch: Run component via the batch system?
         """
-        super().__init__(config=config, dry_run=dry_run, batch=batch)
-        self._config.dereference(context={"cycle": cycle})
+        super().__init__(config=config, dry_run=dry_run, batch=batch, cycle=cycle)
         if self._dry_run:
             dryrun()
         self._cycle = cycle

--- a/src/uwtools/drivers/ungrib.py
+++ b/src/uwtools/drivers/ungrib.py
@@ -118,7 +118,8 @@ class Ungrib(Driver):
         path = self._rundir / "Vtable"
         yield self._taskname(str(path))
         yield asset(path, path.is_symlink)
-        yield None
+        infile = Path(self._driver_config["vtable"])
+        yield file(path=infile)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.symlink_to(Path(self._driver_config["vtable"]))
 

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -10,10 +10,11 @@ from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
 import yaml
-from pytest import fixture
+from pytest import fixture, raises
 
 from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.drivers import driver
+from uwtools.exceptions import UWConfigError
 
 # Helpers
 
@@ -162,12 +163,18 @@ def test_Driver__driver_config(driverobj):
     }
 
 
-def test_Driver__resources(driverobj):
+def test_Driver__resources_fail(driverobj):
+    del driverobj._config["platform"]
+    with raises(UWConfigError) as e:
+        assert driverobj._resources
+    assert str(e.value) == "Required 'platform' block missing in config"
+
+
+def test_Driver__resources_pass(driverobj):
     account = "me"
     scheduler = "slurm"
     walltime = "00:05:00"
     driverobj._driver_config["execution"].update({"batchargs": {"walltime": walltime}})
-    driverobj._config["platform"] = {"account": account, "scheduler": scheduler}
     assert driverobj._resources == {
         "account": account,
         "rundir": driverobj._rundir,

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -154,7 +154,14 @@ def test_Driver__create_user_updated_config_base_file(
     assert updated == expected
 
 
-def test_Driver__driver_config(driverobj):
+def test_Driver__driver_config_fail(driverobj):
+    del driverobj._config["concrete"]
+    with raises(UWConfigError) as e:
+        assert driverobj._driver_config
+    assert str(e.value) == "Required 'concrete' block missing in config"
+
+
+def test_Driver__driver_config_pass(driverobj):
     assert set(driverobj._driver_config.keys()) == {
         "base_file",
         "execution",

--- a/src/uwtools/tests/drivers/test_ungrib.py
+++ b/src/uwtools/tests/drivers/test_ungrib.py
@@ -73,13 +73,13 @@ def test_Ungrib_dry_run(config_file, cycle):
     dryrun.assert_called_once_with()
 
 
-def test_Ungrib_gribfile_aaa(driverobj):
+def test_Ungrib_gribfile(driverobj):
     src = driverobj._rundir / "GRIBFILE.AAA.in"
     src.touch()
     driverobj._driver_config["gfs_file"] = src
     dst = driverobj._rundir / "GRIBFILE.AAA"
     assert not dst.is_symlink()
-    driverobj.gribfile_aaa()
+    driverobj.gribfile()
     assert dst.is_symlink()
 
 
@@ -94,7 +94,7 @@ def test_Ungrib_namelist_file(driverobj):
 def test_Ungrib_provisioned_run_directory(driverobj):
     with patch.multiple(
         driverobj,
-        gribfile_aaa=D,
+        gribfile=D,
         namelist_file=D,
         runscript=D,
         vtable=D,

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -173,7 +173,7 @@ def test__add_subparser_template_translate(subparsers):
 def test__add_subparser_ungrib(subparsers):
     cli._add_subparser_ungrib(subparsers)
     assert actions(subparsers.choices[STR.ungrib]) == [
-        "gribfile_aaa",
+        "gribfile",
         "namelist_file",
         "provisioned_run_directory",
         "run",


### PR DESCRIPTION
**Synopsis**

- Pass `cycle` parameter from `Driver` subclasses that use it to base-class constructor so that a single dereference can fully render template expressions using `cycle`. See comment/example in _Files changed_.
- Gracefully handle missing `platform` or driver-name (e.g. `chgres_cube`, `ungrib`) blocks in UW YAML. See comment/example in _Files changed_.
- Rename `gribfile_aaa` `ungrib` task to `gribfile` to be less specific, in case we update this task to create multiple GRIB inputs.
- Update `ungrib` `vtable` task to require target file before creating symlink. See comment/example in _Files changed_.
- In driver docstrings, fix punctuation and set consistent description for `cycle` parameter.
- Update CLI test to call `uw --version`.
- Remove inconsistent/unnecessary quotes in YAML snippets.
- Update unit tests to cover the above changes.

**Type**

- [x] Bug fix (corrects a known issue)
- [x] Documentation
- [x] Enhancement (adds a new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
